### PR TITLE
Fix bug when mixing CONDA_ENVS_PATH with win32 and win64 environments

### DIFF
--- a/conda/config.py
+++ b/conda/config.py
@@ -165,7 +165,7 @@ def pkgs_dir_from_envs_dir(envs_dir):
     if abspath(envs_dir) == abspath(join(root_dir, 'envs')):
         return join(root_dir, 'pkgs32' if force_32bit else 'pkgs')
     else:
-        return join(envs_dir, '.pkgs')
+        return join(envs_dir, '.pkgs32' if force_32bit else '.pkgs')
 
 pkgs_dirs = [pkgs_dir_from_envs_dir(envs_dir) for envs_dir in envs_dirs]
 


### PR DESCRIPTION
fix #1885
